### PR TITLE
Minor documentation changes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -11,9 +11,9 @@ of the caller is to to have an SRP server and SRP client arrive at the same
 Key. See the documentation for the SRP structure and its methods for the nitty
 gritty of use.
 
-BUG(jpg): This does not use the same padding and hashing scheme as in RFC5054,
+BUG(jpg): This does not use the same padding and hashing scheme as in RFC 5054,
 and therefore is not interoperable with those clients and servers. Perhaps someday
-we'll add an RFC5054 mode that does that, but today is not that day.
+we'll add an RFC 5054 mode that does that, but today is not that day.
 
 The SRP protocol
 

--- a/doc.go
+++ b/doc.go
@@ -99,7 +99,7 @@ User's security responsibilities
 
 The consumer is responsible for
 
-1. Both: Checking whether methods have returned without error.
+1. Both client and server: Checking whether methods have returned without error.
 This is particularly true of SRP.Key() and SetOthersPublic()
 
 2. Client: Using an appropriate key derivation function for deriving x

--- a/group.go
+++ b/group.go
@@ -4,12 +4,10 @@ import (
 	"math/big"
 )
 
-// Group has a generator, g, and a modulus, N.
-// Also a Label or name that the group can call itself
+// Group is a Diffie-Hellman group and has an unexported generator and modulus.
+// It has a Label or name that the group can call itself.
 // Recommended ExponentSize (in bytes) is based on the
-// lower estimates given in section 8 of RFC3526
-// Silly golang capitialization rules mean I have
-// to call "N" something else to prevent export
+// lower estimates given in section 8 of RFC3526 for the ephemeral random exponents.
 type Group struct {
 	g, n         *big.Int
 	Label        string
@@ -47,14 +45,14 @@ const (
 	RFC5054Group8192 = 7
 )
 
-// KnownGroups is a map from strings to Diffie-Hellman group parameters
+// KnownGroups is a map from strings to Diffie-Hellman group parameters.
 var KnownGroups = make(map[int]*Group)
 
 // MinGroupSize (in bits) sets a lower bound on the size of DH groups
 // that will pass certain internal checks. Defaults to 2048
 var MinGroupSize = 2048
 
-// MinExponentSize (in bytes) for generating ephemeral private keys
+// MinExponentSize (in bytes) for generating ephemeral private keys.
 var MinExponentSize = 32
 
 func init() {

--- a/group.go
+++ b/group.go
@@ -7,7 +7,7 @@ import (
 // Group is a Diffie-Hellman group and has an unexported generator and modulus.
 // It has a Label or name that the group can call itself.
 // Recommended ExponentSize (in bytes) is based on the
-// lower estimates given in section 8 of RFC3526 for the ephemeral random exponents.
+// lower estimates given in section 8 of RFC 3526 for the ephemeral random exponents.
 type Group struct {
 	g, n         *big.Int
 	Label        string

--- a/group.go
+++ b/group.go
@@ -32,9 +32,9 @@ func (g *Group) Generator() *big.Int {
 	return g.g
 }
 
-// RFC5054 groups are listed by their numbers in Appendix A of the RFC
+// RFC 5054 groups are listed by their numbers in Appendix A of the RFC
 const (
-	// The values correspond to the numbering in Appendix A of RFC5054
+	// The values correspond to the numbering in Appendix A of RFC 5054
 	// so not using iota mechanism for numbering here.
 	RFC5054Group1024 = 1 // We won't allow this group
 	RFC5054Group1536 = 2 // We aren't going to allow this one either

--- a/internal.go
+++ b/internal.go
@@ -8,18 +8,17 @@ import (
 )
 
 /*
-
-The princple srp.go file was getting too long, so I'm putting the non-exported
+The principle srp.go file was getting too long, so I'm putting the non-exported
 methods in here.
 */
 
 // generateMySecret creates the little a or b
-// According to RFC5054, this should be at least 32 bytes
-// According to RFC2631 this should be uniform in the range
+// According to RFC 5054, this should be at least 32 bytes
+// According to RFC 2631 this should be uniform in the range
 // [2, q-2], where q is the Sofie Germain prime from which
 // N was created.
-// According to RFC3526 §8 there are some specific sizes depending
-// on the group. We go with RFC3526 values if available, otherwise
+// According to RFC 3526 §8 there are some specific sizes depending
+// on the group. We go with RFC 3526 values if available, otherwise
 // a minimum of 32 bytes.
 
 func (s *SRP) generateMySecret() *big.Int {
@@ -35,7 +34,7 @@ func (s *SRP) generateMySecret() *big.Int {
 
 // makeLittleK initializes multiplier based on group paramaters
 // k = H(N, g)
-// BUG(jpg): Creation of multiplier, little k, does _not_ confirm to RFC5054 padding
+// BUG(jpg): Creation of multiplier, little k, does _not_ confirm to RFC 5054 padding
 func (s *SRP) makeLittleK() (*big.Int, error) {
 	if s.group == nil {
 		return nil, fmt.Errorf("group not set")

--- a/kdf.go
+++ b/kdf.go
@@ -10,7 +10,7 @@ import (
 )
 
 /*
- * Best to use KDF from github/agilebits/op/cryto
+ * Best to use KDF from github/agilebits/op/crypto
  * I will import at some point
  */
 

--- a/kdf.go
+++ b/kdf.go
@@ -15,8 +15,8 @@ import (
  */
 
 /*
-KDFRFC5054 is *not* recommended. Instead use a KDF that
-involes a hashing scheme designed for password hashing.
+KDFRFC5054 is *not* recommended. Instead use a key derivation function (KDF) that
+involves a hashing scheme designed for password hashing.
 The SRP verifier that is stored by the server is like
 a password hash with respect to crackability. Choose a KDF
 that that makes the server stored verifiers hard to crack.
@@ -25,7 +25,7 @@ This computes the client's long term secret, x
 from  a username, password, and salt as described
 in RFC5054 §2.6, which says
     x = SHA1(s | SHA1(I | ":" | P))
-**/
+*/
 func KDFRFC5054(salt []byte, username string, password string) (x *big.Int) {
 
 	p := []byte(PreparePassword(password))

--- a/kdf.go
+++ b/kdf.go
@@ -23,7 +23,7 @@ that that makes the server stored verifiers hard to crack.
 
 This computes the client's long term secret, x
 from  a username, password, and salt as described
-in RFC5054 §2.6, which says
+in RFC 5054 §2.6, which says
     x = SHA1(s | SHA1(I | ":" | P))
 */
 func KDFRFC5054(salt []byte, username string, password string) (x *big.Int) {

--- a/srp.go
+++ b/srp.go
@@ -44,8 +44,10 @@ A typical use by a server might be something like
 
 	// You must still prove that both server and client created the same Key.
 
-This still leaves some work outside of what the SRP object provides.
+This still leaves some work outside of what the SRP object provides:
+
 1. The key derivation of x is not handled by this object.
+
 2. The communication between client and server is not handled by this object.
 */
 type SRP struct {


### PR DESCRIPTION
Minor changes to documentation. A few typos, a few instances of picking better wording.

## Testing

To view godoc results locally,

1. Run `godoc -http=:6060` 
2. Look at  http://localhost:6060/pkg/github.com/agilebits/srp/

- [x] `go test` passes all tests
- [x] godoc rendering appears sane