### PR TITLE
Jpg/validate u 21

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -149,6 +149,9 @@ func (s *SRP) calculateU() (*big.Int, error) {
 
 	u := &big.Int{}
 	s.u = u.SetBytes(h.Sum(nil))
+	if s.u.Cmp(bigZero) == 0 {
+		return nil, fmt.Errorf("u == 0, which is a bad thing")
+	}
 	return s.u, nil
 }
 

--- a/srp.go
+++ b/srp.go
@@ -254,10 +254,15 @@ func (s *SRP) Key() ([]byte, error) {
 	if s.group == nil {
 		return nil, fmt.Errorf("group not set")
 	}
-	if !s.isUValid() {
+	// Because of tests, we don't want to always recalculate u
+	if s.u == nil {
 		if u, err := s.calculateU(); u == nil || err != nil {
 			return nil, fmt.Errorf("failed to calculate u: %s", err)
 		}
+	}
+	if !s.isUValid() {
+		s.badState = true
+		return nil, fmt.Errorf("invalid u")
 	}
 	if s.ephemeralPrivate.Cmp(bigZero) == 0 {
 		return nil, fmt.Errorf("cannot make Key with my ephemeral secret")

--- a/srp.go
+++ b/srp.go
@@ -207,7 +207,7 @@ func (s *SRP) Verifier() (*big.Int, error) {
 // Caller *MUST* check for error status and abort the session
 // on error. This setter will invoke IsPublicValid() and error
 // status must be heeded, as other party may attempt to send
-// a malicious emphemeral public key (A or B).
+// a malicious ephemeral public key (A or B).
 //
 // When used by the server, this sets A, when used by the client
 // it sets B. But caller doesn't need to worry about whether this

--- a/srp.go
+++ b/srp.go
@@ -255,11 +255,12 @@ func (s *SRP) Key() ([]byte, error) {
 		return nil, fmt.Errorf("group not set")
 	}
 	// Because of tests, we don't want to always recalculate u
-	if s.u == nil {
+	if !s.isUValid() {
 		if u, err := s.calculateU(); u == nil || err != nil {
 			return nil, fmt.Errorf("failed to calculate u: %s", err)
 		}
 	}
+	// We must refuse to calculate Key when u == 0
 	if !s.isUValid() {
 		s.badState = true
 		return nil, fmt.Errorf("invalid u")


### PR DESCRIPTION
Resolve #21 

We weren't checking that u != 0 after we created u. The obvious fix, broke some tests (which involve manually setting u, so we still check for whether u is valid before generating u. Now we also check afterwards as well.